### PR TITLE
Convert TP PDF handouts to Markdown

### DIFF
--- a/Cours/TP1/TP_Pandas_Enonce.md
+++ b/Cours/TP1/TP_Pandas_Enonce.md
@@ -1,0 +1,26 @@
+TP Pandas (≈ 1h) — Dataset Iris
+Objectifs
+Télécharger un jeu de données existant (Iris via scikit-learn), le charger dans pandas puis réaliser des manipulations et des visualisations avec matplotlib.
+Prérequis
+Python 3.x, pandas, scikit-learn, matplotlib.
+Consignes
+Importer le dataset Iris depuis scikit-learn (`from sklearn.datasets import load_iris`).
+Construire un DataFrame pandas avec les colonnes : sepal_length, sepal_width, petal_length, petal_width, species.
+Effectuer des manipulations courantes (statistiques, filtrage, renommage, ajout/suppression de colonnes/lignes).
+Produire des graphiques avec matplotlib (pas de seaborn requis).
+Travail demandé
+Charger Iris et afficher les 5 premières lignes + la taille du DataFrame.
+Afficher df.info() et df.describe().
+Renommer les colonnes en SepalLengthCm, SepalWidthCm, PetalLengthCm, PetalWidthCm, Species.
+Ajouter la colonne PetalRatio = PetalLengthCm / PetalWidthCm et SepalRatio = SepalLengthCm * SepalWidthCm.
+Supprimer la colonne  SepalRatio.
+Supprimer les lignes où SepalLengthCm < 5.0.
+Filtrer uniquement les lignes de l’espèce setosa.
+Compter le nombre d’occurrences par espèce (table de fréquences).
+Visualiser : (1) un histogramme d’une variable numérique, (2) un nuage de points entre deux variables, (3) un boxplot par espèce, (4) un diagramme en barres du compte par espèce.
+Conseils
+Utilisez load_iris(as_frame=True) pour obtenir un DataFrame facilement.
+Pour le scatter : plt.scatter(x, y) puis plt.xlabel, plt.ylabel, plt.title.
+Pour le boxplot : plt.boxplot avec une liste de séries (une par espèce).
+Pensez à plt.figure() avant chaque graphique pour éviter les chevauchements.
+Durée estimée : 1h

--- a/Cours/TP2_Clustering/TP2_enonce.md
+++ b/Cours/TP2_Clustering/TP2_enonce.md
@@ -1,0 +1,43 @@
+TP2 – Clustering par K-Means
+
+Introduction au clustering
+Le clustering est une famille de méthodes d'apprentissage non supervisé qui regroupe automatiquement des observations similaires. L'objectif est de révéler des structures latentes dans les données afin de mieux comprendre des comportements, personnaliser des offres ou détecter des anomalies.
+Dans un contexte marketing, segmenter un portefeuille clients permet par exemple d'adapter les campagnes, optimiser les recommandations produit et mesurer la valeur de chaque groupe.
+
+Figure 1 – Exemple de regroupement visuel de clients selon leur revenu annuel et leur score de dépenses.
+
+Algorithme K-Means
+K-Means est l'un des algorithmes de clustering les plus utilisés pour créer k groupes homogènes. Il repose sur la minimisation de la distance entre chaque point et le centre de son cluster.
+Principales étapes :
+1) Initialiser k centroïdes (aléatoirement ou via une méthode avancée comme k-means++).
+2) Assigner chaque observation au centroïde le plus proche (distance euclidienne par défaut).
+3) Recalculer la position des centroïdes comme moyenne des points de leur cluster.
+4) Répéter les étapes 2 et 3 jusqu’à convergence (changement négligeable des centroïdes ou nombre d’itérations atteint).
+Le choix de k influence directement la qualité de la segmentation : trop faible, les groupes sont trop larges; trop élevé, ils deviennent difficilement exploitables.
+
+Méthode du coude (Elbow method)
+La méthode du coude aide à sélectionner un k pertinent. On entraîne K-Means pour différents k, puis on trace l'évolution de l'inertie (somme des distances au carré des points à leur centroïde).
+Lorsque la courbe forme un coude, cela signifie que l'amélioration marginale de l'inertie devient faible : ce k constitue un bon compromis entre compacité des clusters et simplicité du modèle.
+
+Figure 2 – Illustration de la méthode du coude : le point k=5 matérialise un bon équilibre.
+
+Contexte et objectifs
+L'entreprise gérant un centre commercial souhaite mieux comprendre les profils de ses clients afin de personnaliser ses actions marketing. Vous allez mettre en œuvre l'algorithme de clustering K-Means pour segmenter les clients en fonction de leur revenu annuel et de leur score de dépenses.
+
+Jeu de données
+Le jeu de données 'Mall Customers' (CSV) contient des informations anonymisées : Identifiant client, genre, âge, revenu annuel (k$) et score de dépenses (1-100). Les données seront importées depuis l'URL : https://raw.githubusercontent.com/satishgunjal/datasets/master/Mall_Customers.csv.
+
+Prérequis
+Python 3, bibliothèques pandas, numpy, matplotlib et scikit-learn installées. Travaillez dans un notebook Jupyter pour reproduire les cellules de code et documenter vos résultats.
+
+Déroulé du TP
+1. Initialisez votre environnement en important pandas, numpy, matplotlib.pyplot (sous l'alias plt) et KMeans depuis sklearn.cluster.
+2. Chargez le jeu de données dans un DataFrame pandas depuis l'URL fournie. Vérifiez les dimensions du tableau et affichez les premières lignes pour valider le chargement.
+3. Répondez aux questions d'exploration : quelles sont les statistiques descriptives des variables numériques ? Y a-t-il des valeurs nulles ? Utilisez df.describe() et df.info().
+4. Renommez les colonnes 'Annual Income (k$)' et 'Spending Score (1-100)' en 'AnnualIncome' et 'SpendingScore' pour faciliter la manipulation. Contrôlez le résultat en affichant df.columns.
+5. Proposez une première visualisation du couple (AnnualIncome, SpendingScore) à l'aide d'un nuage de points. Interprétez brièvement la répartition obtenue.
+6. Construisez la matrice de caractéristiques X à partir des colonnes AnnualIncome et SpendingScore (utilisez df.loc[:, ["AnnualIncome", "SpendingScore"]].values) et vérifiez les premières lignes.
+7. Déterminez un nombre de clusters pertinent en appliquant la méthode du coude : pour k allant de 1 à 10, entraînez un modèle KMeans (initialisation aléatoire, random_state=42) et stockez l'inertie associée. Tracez l'évolution de l'inertie en fonction de k et commentez le point de coude.
+8. Entraînez un modèle KMeans avec k=5 (random_state=42) sur la matrice X. Récupérez les étiquettes prédites pour chaque client.
+9. Ajoutez ces étiquettes comme nouvelle colonne 'Cluster' dans le DataFrame d'origine. Analysez les caractéristiques de chaque segment : effectifs par cluster, moyenne du revenu et du score de dépenses.
+10. Visualisez les clusters sur le plan (AnnualIncome, SpendingScore) en attribuant une couleur par segment. Vérifiez la cohérence avec vos observations précédentes.

--- a/Cours/TP3_Classification/TP_Classification_ML_Enonce_v3.md
+++ b/Cours/TP3_Classification/TP_Classification_ML_Enonce_v3.md
@@ -1,0 +1,74 @@
+TP : Classification en Machine Learning
+
+Algorithmes de classification utilisés
+Avant de commencer le TP, nous allons présenter les algorithmes qui seront utilisés. Chaque méthode a ses forces, ses faiblesses et ses paramètres clés à optimiser. Des schémas et images sont fournis (liens ou générés automatiquement) pour aider à la compréhension.
+1) Decision Tree (Arbre de décision)
+Principe : un arbre de décision segmente l’espace des variables par une série de questions du type « la valeur de feature X est-elle > à un seuil ? ». Chaque nœud correspond à une décision, et les feuilles correspondent aux classes prédites.
+- Avantages : interprétable, simple à visualiser, peu de preprocessing nécessaire.
+- Inconvénients : tendance à sur-apprendre (overfitting) si l’arbre est trop profond.
+Hyperparamètres importants :
+- `max_depth` : limite la profondeur de l’arbre.
+- `min_samples_split` : nb minimal d’échantillons pour diviser un nœud.
+- `min_samples_leaf` : nb minimal d’échantillons dans une feuille.
+- `criterion` : mesure d’impureté (entropy, gini).
+https://www.youtube.com/watch?v=ZVR2Way4nwQ
+
+2) Random Forest
+Principe : une forêt aléatoire est composée de nombreux arbres de décision. Chaque arbre est construit sur un sous-échantillon des données et un sous-ensemble de variables. La prédiction finale est obtenue par vote majoritaire.
+- Avantages : robuste, réduit l’overfitting par rapport à un seul arbre, performant sans tuning complexe.
+- Inconvénients : moins interprétable qu’un arbre unique, plus coûteux en calcul.
+Hyperparamètres importants :
+- `n_estimators` : nombre d’arbres.
+- `max_depth` : profondeur max des arbres.
+- `max_features` : nb de variables prises en compte à chaque split.
+- `min_samples_leaf` : nb minimal d’échantillons dans une feuille.
+https://www.youtube.com/watch?v=v6VJ2RO66Ag
+3) XGBoost (eXtreme Gradient Boosting)
+Principe : le boosting construit les arbres séquentiellement. Chaque nouvel arbre corrige les erreurs des arbres précédents. XGBoost est une implémentation optimisée et très utilisée du gradient boosting.
+- Avantages : souvent l’algorithme le plus performant sur données tabulaires.
+- Inconvénients : tuning plus complexe, temps d’entraînement parfois élevé.
+Hyperparamètres importants :
+- `n_estimators` : nb d’arbres.
+- `learning_rate` : taux d’apprentissage (impact de chaque arbre).
+- `max_depth` : profondeur max.
+- `subsample` : fraction d’échantillons utilisés par arbre.
+- `colsample_bytree` : fraction de variables utilisées par arbre.
+Principe du train_test_split
+Lorsqu’on entraîne un modèle de machine learning, il est essentiel de pouvoir évaluer ses performances sur des données jamais vues. On sépare donc le dataset en deux parties :
+- **train set** : utilisé pour l’apprentissage du modèle.
+- **test set** : utilisé uniquement pour l’évaluation finale.
+
+Exemple typique : 80% pour l’entraînement et 20% pour le test, en respectant la proportion des classes (stratification).
+https://www.youtube.com/watch?v=SjOfbbfI2qY
+
+Métriques d’évaluation en classification
+Pour juger la qualité d’un modèle de classification, plusieurs métriques sont utilisées :
+- **Accuracy** : proportion de prédictions correctes.
+- **Precision** : parmi les prédictions positives, combien sont réellement positives ?
+- **Recall (sensibilité)** : parmi les vrais positifs, combien sont retrouvés par le modèle ?
+- **F1-score** : moyenne harmonique de la précision et du rappel, utile quand les classes sont déséquilibrées.
+
+https://www.youtube.com/watch?v=Kdsp6soqA7o
+
+Objectifs pédagogiques
+- Comprendre et mettre en pratique plusieurs algorithmes de classification : Decision Tree, Random Forest, XGBoost.
+- Savoir préparer un dataset, entraîner, évaluer et comparer des modèles.
+- Analyser et interpréter des résultats (métriques, matrices de confusion, importances de variables).
+Prérequis
+Python, pandas, numpy, matplotlib, notions de scikit-learn.
+Dataset utilisé
+Le TP utilisera le dataset Breast Cancer Wisconsin, intégré à scikit-learn. Il s’agit de prédire si une tumeur est bénigne ou maligne à partir de mesures de cellules.
+
+Déroulé du TP
+1. Présentation des algorithmes.
+2. Chargement et exploration du dataset.
+3. Séparation des données en train/test et preprocessing.
+4. Entraînement des modèles.
+5. Évaluation via métriques globales (accuracy, precision, recall, f1).
+6. Visualisation (matrices de confusion).
+7. Analyse des importances de variables.
+
+8. Comparaison et discussion des résultats.
+Livrables
+- Un notebook Jupyter complété (code + réponses textuelles aux questions).
+- Un court compte rendu (5–10 lignes) comparant les modèles et concluant sur celui qui semble le plus adapté.

--- a/scripts/docx_to_markdown.py
+++ b/scripts/docx_to_markdown.py
@@ -1,0 +1,129 @@
+import zipfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+NS = {'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+
+
+def load_numbering(zf: zipfile.ZipFile) -> dict[str, dict[int, str]]:
+    numbering_map: dict[str, dict[int, str]] = {}
+    if 'word/numbering.xml' not in zf.namelist():
+        return numbering_map
+    root = ET.fromstring(zf.read('word/numbering.xml'))
+    abstract: dict[str, dict[int, str]] = {}
+    for abstr in root.findall('w:abstractNum', NS):
+        aid = abstr.attrib.get(f'{{{NS["w"]}}}abstractNumId')
+        if not aid:
+            continue
+        levels: dict[int, str] = {}
+        for lvl in abstr.findall('w:lvl', NS):
+            ilvl = int(lvl.attrib.get(f'{{{NS["w"]}}}ilvl', '0'))
+            fmt_el = lvl.find('w:numFmt', NS)
+            fmt = fmt_el.attrib.get(f'{{{NS["w"]}}}val') if fmt_el is not None else 'bullet'
+            levels[ilvl] = fmt
+        abstract[aid] = levels
+    for num in root.findall('w:num', NS):
+        num_id = num.attrib.get(f'{{{NS["w"]}}}numId')
+        if not num_id:
+            continue
+        abs_el = num.find('w:abstractNumId', NS)
+        if abs_el is None:
+            continue
+        abstract_id = abs_el.attrib.get(f'{{{NS["w"]}}}val')
+        if not abstract_id:
+            continue
+        numbering_map[num_id] = abstract.get(abstract_id, {})
+    return numbering_map
+
+
+def paragraph_text(para: ET.Element) -> str:
+    parts: list[str] = []
+    for elem in para.iter():
+        if elem.tag == f'{{{NS["w"]}}}t':
+            parts.append(elem.text or '')
+        elif elem.tag == f'{{{NS["w"]}}}tab':
+            parts.append('\t')
+        elif elem.tag == f'{{{NS["w"]}}}br':
+            parts.append('\n')
+    return ''.join(parts)
+
+
+def docx_to_markdown(path: Path) -> str:
+    with zipfile.ZipFile(path) as zf:
+        document = ET.fromstring(zf.read('word/document.xml'))
+        numbering = load_numbering(zf)
+    lines: list[str] = []
+    counters: dict[str, dict[int, int]] = {}
+    for para in document.findall('.//w:p', NS):
+        raw_text = paragraph_text(para).strip()
+        ppr = para.find('w:pPr', NS)
+        if not raw_text:
+            lines.append('')
+            continue
+        style = None
+        if ppr is not None:
+            style_el = ppr.find('w:pStyle', NS)
+            if style_el is not None:
+                style = style_el.attrib.get(f'{{{NS["w"]}}}val', '').lower()
+        if style and style.startswith('heading'):
+            try:
+                level = int(style.replace('heading', '') or '1')
+            except ValueError:
+                level = 1
+            level = max(1, min(level, 6))
+            lines.append(f"{'#' * level} {raw_text}")
+            continue
+        num_line = None
+        if ppr is not None:
+            num_pr = ppr.find('w:numPr', NS)
+            if num_pr is not None:
+                num_id_el = num_pr.find('w:numId', NS)
+                ilvl_el = num_pr.find('w:ilvl', NS)
+                if num_id_el is not None:
+                    num_id = num_id_el.attrib.get(f'{{{NS["w"]}}}val', '0')
+                    level = int(ilvl_el.attrib.get(f'{{{NS["w"]}}}val', '0')) if ilvl_el is not None else 0
+                    fmt = numbering.get(num_id, {}).get(level, 'bullet')
+                    indent = '  ' * level
+                    if fmt == 'decimal':
+                        counters.setdefault(num_id, {})
+                        for lv in list(counters[num_id]):
+                            if lv > level:
+                                del counters[num_id][lv]
+                        counters[num_id][level] = counters[num_id].get(level, 0) + 1
+                        num_line = f"{indent}{counters[num_id][level]}. {raw_text}"
+                    else:
+                        counters.setdefault(num_id, {})
+                        for lv in list(counters[num_id]):
+                            if lv >= level:
+                                del counters[num_id][lv]
+                        num_line = f"{indent}- {raw_text}"
+        if num_line is not None:
+            lines.append(num_line)
+        else:
+            lines.append(raw_text)
+    cleaned: list[str] = []
+    blank = False
+    for line in lines:
+        if line.strip():
+            cleaned.append(line)
+            blank = False
+        else:
+            if not blank:
+                cleaned.append('')
+            blank = True
+    return '\n'.join(cleaned).rstrip() + '\n'
+
+
+def main() -> None:
+    for pdf_path in Path('Cours').rglob('*.pdf'):
+        docx_path = pdf_path.with_suffix('.docx')
+        if not docx_path.exists():
+            print(f'No DOCX counterpart for {pdf_path}')
+            continue
+        md_path = pdf_path.with_suffix('.md')
+        md_path.write_text(docx_to_markdown(docx_path), encoding='utf-8')
+        print(f'Converted {docx_path} -> {md_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- convert the TP1, TP2 and TP3 PDF course handouts into readable Markdown files derived from their DOCX sources
- add a reusable `docx_to_markdown.py` helper that turns DOCX documents in `Cours/` into Markdown counterparts

## Testing
- python scripts/docx_to_markdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c38c7fcc832e8b1423054d3aa9fb