### PR TITLE
Refactor TP7 into four detailed preprocessing workshops

### DIFF
--- a/Cours/TP7_Pretraitement_Variables/TP7_1_Selection_Variables.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_1_Selection_Variables.md
@@ -1,0 +1,97 @@
+# TP7.1 — Sélection de variables explicatives
+
+## Positionnement pédagogique
+- **Durée indicative** : 3 heures.
+- **Niveau** : étudiants de 3e année de BUT Informatique (parcours IA/Data).
+- **Compétences visées** : compréhension des critères de sélection, mise en œuvre de pipelines scikit-learn, analyse critique des résultats.
+
+## Objectifs d'apprentissage
+1. Identifier les variables pertinentes pour prédire une cible binaire.
+2. Comparer plusieurs approches de sélection et comprendre leurs hypothèses.
+3. Mesurer l'impact de la sélection sur les performances et la complexité des modèles.
+
+## Mise en route
+1. Charger le dataset Adult Income (`fetch_openml`).
+2. Séparer les features (`X`) de la cible (`y`).
+3. Identifier les colonnes numériques et catégorielles (`select_dtypes`).
+4. Construire un `ColumnTransformer` minimal pour gérer les types de variables :
+   ```python
+   from sklearn.compose import ColumnTransformer
+   from sklearn.preprocessing import OneHotEncoder
+
+   numeric_features = X.select_dtypes(include=["int64", "float64"]).columns
+   categorical_features = X.select_dtypes(include=["object", "category"]).columns
+
+   preprocess = ColumnTransformer([
+       ("num", "passthrough", numeric_features),
+       ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features),
+   ])
+   ```
+
+> 💡 *Astuce pédagogique* : Vérifiez la taille des données transformées (`shape`) pour prendre conscience de l'explosion dimensionnelle liée au one-hot encoding.
+
+## Activité 1 — Analyse univariée (45 min)
+1. **Objectif** : mesurer l'association de chaque variable indépendante avec la variable cible.
+2. **Méthodes proposées** :
+   - `SelectKBest` avec `chi2` (sur données catégorielles encodées et positives) ;
+   - `SelectKBest` avec `mutual_info_classif` (robuste aux relations non linéaires).
+3. **Plan d'action** :
+   - Intégrer le `SelectKBest` dans un pipeline avec une régression logistique.
+   - Tester `k ∈ {10, 20, 40}`.
+   - Utiliser une validation croisée (`cross_val_score`, `StratifiedKFold`) pour estimer `accuracy`, `f1` et `roc_auc`.
+4. **Analyse attendue** :
+   - Graphique `k` vs `score` pour chaque métrique.
+   - Identification des variables sélectionnées pour chaque `k` (lister les noms grâce à `get_support`).
+   - Commentaire : quels types de variables ressortent ? Y a-t-il des surprises ?
+
+> 🧪 *À rendre* : tableau comparatif des scores, interprétation écrite (5 lignes).
+
+## Activité 2 — Sélection basée sur un modèle (60 min)
+1. **Objectif** : utiliser un modèle capable de pondérer l'importance des variables pour décider lesquelles conserver.
+2. **Modèles suggérés** :
+   - `RandomForestClassifier` avec `SelectFromModel` ;
+   - `LogisticRegression(penalty="l1", solver="liblinear")` pour appliquer une pénalité Lasso.
+3. **Étapes détaillées** :
+   - Créer deux pipelines séparés (forêt aléatoire vs régression logistique pénalisée).
+   - Ajuster l'hyperparamètre de régularisation (`C`) ou le seuil d'importance pour contrôler le nombre de variables retenues.
+   - Évaluer chaque pipeline via validation croisée (métriques : `f1`, `balanced_accuracy`, `roc_auc`).
+4. **Questions de réflexion** :
+   - Les variables sélectionnées par la forêt sont-elles identiques à celles du Lasso ? Pourquoi ?
+   - Comment justifier le choix d'un seuil (par exemple `median`) pour `SelectFromModel` ?
+
+> 📌 *Aller plus loin* : visualiser les importances normalisées (`feature_importances_` ou `coef_`) et discuter de leur interprétation.
+
+## Activité 3 — Sélection séquentielle (45 min)
+1. **Objectif** : comprendre les approches incrémentales (`SequentialFeatureSelector`).
+2. **Méthodologie** :
+   - Utiliser une régression logistique comme estimateur de base.
+   - Configurer deux sélecteurs : `direction="forward"` et `direction="backward"`.
+   - Limiter le nombre de variables recherchées (ex. `n_features_to_select=25`) pour contenir les temps de calcul.
+3. **Consignes** :
+   - Mesurer le temps d'exécution (module `time`).
+   - Comparer les scores de validation croisée aux méthodes précédentes.
+   - Discuter des compromis entre performance et coût de calcul.
+
+> ⏱️ *Attention* : documentez les temps d'exécution dans le notebook pour argumenter vos choix.
+
+## Activité 4 — Impact sur XGBoost (30 min)
+1. **Contexte** : XGBoost gère déjà un mécanisme de sélection interne via le gain d'information.
+2. **Expérimentation** :
+   - Créer un pipeline avec prétraitement minimal (`OneHotEncoder` uniquement pour les catégories).
+   - Entrainer deux modèles XGBoost :
+     - `XGBClassifier` sur l'ensemble complet ;
+     - le même modèle sur les variables retenues par la méthode jugée la plus pertinente (Activités 1 à 3).
+   - Comparer temps d'entraînement, `f1`, `roc_auc`.
+3. **Analyse** : commenter l'intérêt (ou non) de filtrer les variables avant XGBoost.
+
+## Synthèse à produire
+- Tableau récapitulatif : méthode de sélection / nombre de variables / métriques principales / temps d'entraînement.
+- Conclusion (8 à 10 lignes) :
+  - Quelle méthode est la plus adaptée à ce dataset ?
+  - Quelles sont les limites observées ?
+  - Quels critères utiliseriez-vous pour choisir une méthode dans un nouveau projet ?
+
+## Ressources complémentaires
+- Documentation scikit-learn : [Feature selection](https://scikit-learn.org/stable/modules/feature_selection.html)
+- Article de blog recommandé : *Feature Selection Techniques in Machine Learning* (Analytics Vidhya).
+- Tutoriel vidéo (facultatif) : *Feature Selection in Python* (StatQuest).

--- a/Cours/TP7_Pretraitement_Variables/TP7_2_Normalisation_Encodage.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_2_Normalisation_Encodage.md
@@ -1,0 +1,90 @@
+# TP7.2 — Normalisation et encodage des variables
+
+## Positionnement pédagogique
+- **Durée indicative** : 3 heures.
+- **Niveau** : BUT3 Informatique.
+- **Compétences visées** : choix d'un schéma de transformation adapté au type de données, mise en œuvre de pipelines, prévention des fuites de données.
+
+## Objectifs d'apprentissage
+1. Comprendre pourquoi normaliser/standardiser les variables numériques.
+2. Choisir un encodage pertinent pour les variables catégorielles en fonction du modèle cible.
+3. Construire des pipelines reproductibles combinant transformations et modèles de classification.
+
+## Cadre de travail
+- Dataset : Adult Income (`fetch_openml`).
+- Séparer `X` et `y`, puis découper le dataset en `train`/`test` stratifiés (`train_test_split`).
+- Conserver une partie du jeu de test *non transformée* jusqu'à l'évaluation finale (pas de `fit` sur le test !).
+
+## Activité 1 — Cartographier les types de variables (20 min)
+1. Créer un tableau récapitulatif listant pour chaque colonne : type (`numérique`/`catégorielle`), nombre de modalités (catégorielles), présence de valeurs manquantes.
+2. Visualiser rapidement la distribution de 3 variables numériques (`histplot` ou `boxplot`) et de 3 variables catégorielles (`value_counts()` + diagramme en barres).
+3. Déduire les transformations potentielles (besoin de normalisation ? encodage ordinal pertinent ?).
+
+## Activité 2 — Choix et comparaison des scalers (45 min)
+1. Construire trois pipelines identiques (prétraitement + régression logistique) qui ne diffèrent que par le scaler appliqué aux numériques :
+   - `StandardScaler`
+   - `MinMaxScaler`
+   - `RobustScaler`
+2. Évaluer via validation croisée (`StratifiedKFold`, 5 folds) les métriques `accuracy`, `f1`, `roc_auc`.
+3. Analyser l'impact sur la stabilité des coefficients (`coef_`) de la régression.
+4. Question de réflexion : quelles situations du monde réel justifient l'usage de chacun de ces scalers ?
+
+> ✍️ *À consigner* : un tableau comparatif des scores moyens et écarts-types.
+
+## Activité 3 — Encodage des catégories (60 min)
+1. Implémenter trois stratégies :
+   - `OneHotEncoder` (baseline).
+   - `OrdinalEncoder` avec un ordre logique pour `education` (par exemple : du niveau le plus faible au plus élevé).
+   - `TargetEncoder` (via `category_encoders`).
+2. Pour `TargetEncoder`, mettre en place une validation rigoureuse :
+   - Utiliser `KFoldTargetEncoder` ou envelopper l'encodeur dans un pipeline avec `ColumnTransformer` + validation croisée pour éviter les fuites.
+3. Évaluer chaque stratégie avec deux modèles : régression logistique et k-NN (`KNeighborsClassifier`).
+4. Comparer les performances et discuter des limites :
+   - Explosion du nombre de colonnes (OneHot).
+   - Risque de sur-apprentissage (TargetEncoder).
+   - Perte d'information sur l'ordre réel (OrdinalEncoder mal configuré).
+
+> 📊 *Livrable* : un graphique en barres comparant `f1` pour chaque couple (encodeur, modèle).
+
+## Activité 4 — Pipelines avancés et bonnes pratiques (30 min)
+1. Introduire `ColumnTransformer` imbriqué :
+   ```python
+   from sklearn.pipeline import Pipeline
+   from sklearn.impute import SimpleImputer
+
+   numeric_transformer = Pipeline([
+       ("imputer", SimpleImputer(strategy="median")),
+       ("scaler", StandardScaler()),
+   ])
+
+   categorical_transformer = Pipeline([
+       ("imputer", SimpleImputer(strategy="most_frequent")),
+       ("encoder", OneHotEncoder(handle_unknown="ignore")),
+   ])
+
+   preprocess = ColumnTransformer([
+       ("num", numeric_transformer, numeric_features),
+       ("cat", categorical_transformer, categorical_features),
+   ])
+   ```
+2. Expliquer l'intérêt d'imputer *dans* le pipeline (pour éviter les fuites et assurer la reproductibilité).
+3. Tester ce pipeline complet avec deux modèles : régression logistique et SVM linéaire (`LinearSVC`).
+4. Mesurer les temps d'entraînement et discuter des différences de performances.
+
+## Activité 5 — Impact sur XGBoost (25 min)
+1. Comparer deux pipelines :
+   - XGBoost avec seulement l'encodage `OneHotEncoder` (pas de scaler).
+   - XGBoost avec encodage catégoriel natif (`enable_categorical=True`) en convertissant les colonnes en `category` puis en `int`.
+2. Évaluer `roc_auc` et `average_precision`.
+3. Discussion :
+   - Quels avantages/inconvénients du support natif des catégories par XGBoost ?
+   - Dans quel cas conserveriez-vous un encodage one-hot malgré tout ?
+
+## Synthèse attendue
+- Tableau final récapitulant pour chaque combinaison (scaler, encodeur, modèle) : temps de fit, nombre de features générées, `f1`, `roc_auc`.
+- Commentaire (8 lignes) expliquant la combinaison retenue pour la suite du parcours.
+
+## Ressources
+- Documentation scikit-learn : [Preprocessing data](https://scikit-learn.org/stable/modules/preprocessing.html)
+- Bibliothèque `category_encoders` : [documentation officielle](https://contrib.scikit-learn.org/category_encoders/)
+- Article : *Handling Categorical Data for Machine Learning* (KDNuggets).

--- a/Cours/TP7_Pretraitement_Variables/TP7_3_Outliers.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_3_Outliers.md
@@ -1,0 +1,73 @@
+# TP7.3 — Détection et traitement des outliers
+
+## Positionnement pédagogique
+- **Durée indicative** : 2h30.
+- **Niveau** : BUT3 Informatique.
+- **Compétences visées** : identification d'observations aberrantes, maîtrise d'algorithmes de détection, intégration dans un pipeline de machine learning.
+
+## Objectifs d'apprentissage
+1. Comprendre l'impact des outliers sur différentes familles de modèles.
+2. Mettre en œuvre des techniques statistiques et algorithmiques de détection.
+3. Choisir une stratégie de traitement (suppression, caping, transformation) adaptée au contexte métier.
+
+## Préparation
+1. Reprendre le dataset Adult Income et les séparations `train`/`test` préparées dans les TP précédents.
+2. Conserver la liste des variables numériques (`numeric_features`).
+3. Créer un notebook dédié pour consigner les analyses visuelles et statistiques.
+
+## Activité 1 — Diagnostic exploratoire (30 min)
+1. Calculer pour chaque variable numérique : moyenne, écart-type, médiane, quantiles (Q1, Q3).
+2. Visualiser les distributions avec des boxplots et histogrammes (`seaborn` recommandé).
+3. Identifier visuellement les valeurs extrêmes et consigner vos observations (variable concernée, nombre de points suspects, hypothèses métier).
+
+> 🗒️ *Astuce* : pensez à travailler sur un échantillon réduit (ex. 5 000 lignes) pour accélérer les visualisations si besoin.
+
+## Activité 2 — Méthodes statistiques (35 min)
+1. Implémenter l'approche IQR (InterQuartile Range) :
+   - Calculer `IQR = Q3 - Q1`.
+   - Définir des seuils : `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`.
+   - Compter le pourcentage de lignes à l'extérieur de ces seuils pour `capital-gain`, `capital-loss`, `hours-per-week`.
+2. Implémenter le z-score :
+   - Standardiser les variables.
+   - Marquer comme outliers les points dont `|z| > 3`.
+3. Comparer IQR vs z-score : quelles variables sont sensibles à la méthode choisie ?
+
+## Activité 3 — Détection automatique (45 min)
+1. Tester trois algorithmes : `IsolationForest`, `LocalOutlierFactor`, `OneClassSVM`.
+2. Pour chacun :
+   - Travailler sur les variables numériques standardisées (`StandardScaler`).
+   - Ajuster l'hyperparamètre principal (`contamination` ou `nu`).
+   - Visualiser les scores/anomalies via un scatter plot (PCA 2D) ou un histogramme des scores.
+3. Comparer les ensembles de points détectés par chaque méthode (utiliser des ensembles Python pour compter les intersections).
+4. Discuter : quelle méthode semble la plus pertinente et pourquoi ? (vitesse, interprétabilité, sensibilité aux paramètres).
+
+> ⚙️ *Conseil* : encapsuler le scaler et l'algorithme dans un pipeline scikit-learn pour éviter les fuites.
+
+## Activité 4 — Stratégies de traitement (30 min)
+1. Implémenter trois stratégies :
+   - **Suppression** : retirer les lignes marquées comme outliers.
+   - **Winsorisation** : tronquer les valeurs extrêmes aux bornes définies par IQR.
+   - **Transformation logarithmique** : appliquer `np.log1p` sur `capital-gain` et `capital-loss`.
+2. Pour chaque stratégie, ré-entraîner :
+   - Une régression logistique (avec pipeline complet du TP7.2).
+   - Un modèle XGBoost (paramètres par défaut).
+3. Comparer `f1`, `roc_auc` et le temps d'entraînement.
+4. Discuter : quelle stratégie maximise le compromis performance/stabilité ?
+
+## Activité 5 — Sensibilité des modèles (20 min)
+1. Mesurer l'impact des outliers sur :
+   - Les coefficients d'une régression logistique (avant/après nettoyage).
+   - Les profondeurs d'arbre apprises par XGBoost (`max_depth` effective via importance des arbres).
+2. Documenter vos observations dans un tableau ou un court commentaire.
+
+## Synthèse attendue
+- Tableau récapitulatif : méthode de détection / pourcentage d'observations marquées / stratégie appliquée / impact sur les métriques.
+- Recommandations (6 à 8 lignes) :
+  - Quelle méthode privilégieriez-vous dans un contexte industriel ?
+  - Comment surveiller la réapparition d'outliers en production ?
+  - Quels tests automatiseriez-vous (ex. alerte si >X % d'outliers) ?
+
+## Ressources
+- Documentation scikit-learn : [Outlier detection](https://scikit-learn.org/stable/modules/outlier_detection.html)
+- Article : *Anomaly Detection Techniques in Python* (Towards Data Science).
+- Tutoriel vidéo : *Isolation Forest Explained* (StatQuest).

--- a/Cours/TP7_Pretraitement_Variables/TP7_4_Classification_Desiquilibree.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_4_Classification_Desiquilibree.md
@@ -1,0 +1,79 @@
+# TP7.4 — Classification déséquilibrée
+
+## Positionnement pédagogique
+- **Durée indicative** : 3 heures.
+- **Niveau** : BUT3 Informatique.
+- **Compétences visées** : traitement des jeux de données déséquilibrés, choix de métriques adaptées, paramétrage d'algorithmes (scikit-learn et XGBoost).
+
+## Objectifs d'apprentissage
+1. Diagnostiquer le niveau de déséquilibre et ses impacts sur les métriques habituelles.
+2. Mettre en place des techniques de rééchantillonnage et de pondération.
+3. Ajuster le seuil de décision et interpréter les courbes ROC/PR.
+4. Paramétrer XGBoost pour des classes minoritaires.
+
+## Préparation
+1. Recharger les datasets `X_train`, `X_test`, `y_train`, `y_test` préparés précédemment (stratifiés).
+2. Réutiliser le pipeline de prétraitement validé dans TP7.2 (normalisation + encodage) comme bloc de base.
+3. Installer `imblearn` si besoin (`pip install imbalanced-learn`).
+
+## Activité 1 — Diagnostic et métriques (25 min)
+1. Calculer la proportion de chaque classe dans le train et le test.
+2. Entraîner une régression logistique *sans* rééquilibrage et évaluer : `accuracy`, `precision`, `recall`, `f1`, `balanced_accuracy`, `roc_auc`, `average_precision`.
+3. Commenter pourquoi l'accuracy peut être trompeuse dans ce contexte.
+4. Visualiser la matrice de confusion et identifier les coûts métiers associés aux faux positifs/faux négatifs.
+
+## Activité 2 — Rééchantillonnage (60 min)
+1. Tester trois stratégies dans une `ImbPipeline` (imblearn) :
+   - `RandomOverSampler`
+   - `SMOTE`
+   - `RandomUnderSampler`
+2. Pour chaque stratégie, utiliser deux modèles : régression logistique et `RandomForestClassifier` (avec `class_weight=None`).
+3. Utiliser une validation croisée stratifiée (5 folds) et comparer `f1`, `recall`, `balanced_accuracy`.
+4. Discuter :
+   - Comment le sur-échantillonnage affecte-t-il le temps d'entraînement ?
+   - Quelles méthodes semblent le mieux préserver la diversité des données ?
+
+> 📈 *Visualisation suggérée* : courbes Precision-Recall pour chaque stratégie.
+
+## Activité 3 — Pondération des classes (35 min)
+1. Évaluer l'effet de `class_weight="balanced"` pour :
+   - Régression logistique (`LogisticRegression`)
+   - SVM linéaire (`LinearSVC`)
+2. Comparer les résultats à ceux de l'Activité 2.
+3. Introduire la notion de `scale_pos_weight` dans XGBoost :
+   ```python
+   from xgboost import XGBClassifier
+
+   scale_pos_weight = len(y_train[y_train == "<=50K"]) / len(y_train[y_train == ">50K"])
+   model = XGBClassifier(scale_pos_weight=scale_pos_weight, eval_metric="aucpr")
+   ```
+4. Tester XGBoost avec et sans pondération.
+
+## Activité 4 — Optimisation du seuil de décision (35 min)
+1. À partir du meilleur modèle (Activité 2 ou 3), récupérer les probabilités (`predict_proba`).
+2. Tracer la courbe Precision-Recall (`sklearn.metrics.precision_recall_curve`).
+3. Définir un seuil maximisant le `f1` ou minimisant un coût métier défini par les étudiants.
+4. Implémenter une fonction utilitaire qui, pour un seuil donné, renvoie la matrice de confusion, `precision`, `recall`, `f1`.
+5. Illustrer l'effet de trois seuils distincts (ex. 0.3, 0.5, 0.7) sur les métriques.
+
+## Activité 5 — Synthèse XGBoost vs modèles linéaires (25 min)
+1. Comparer deux pipelines :
+   - Prétraitement complet + `LogisticRegression` avec la meilleure stratégie (rééchantillonnage ou pondération) + seuil optimisé.
+   - Prétraitement minimal + `XGBClassifier` avec `scale_pos_weight` et early stopping (utiliser `eval_set`).
+2. Évaluer sur le jeu de test : `f1`, `recall`, `roc_auc`, `average_precision`, temps d'entraînement.
+3. Discuter des avantages/inconvénients :
+   - Interprétabilité vs performance brute.
+   - Sensibilité aux hyperparamètres.
+   - Facilité de déploiement.
+
+## Synthèse attendue
+- Tableau comparatif des stratégies testées (rééchantillonnage, pondération, seuils) avec les métriques clés.
+- Recommandations (8 à 10 lignes) :
+  - Quelle stratégie adopter pour un contexte où les faux négatifs sont coûteux ?
+  - Comment monitorer les performances en production (drift de classe) ?
+  - Quels indicateurs suivre en continu (precision@k, recall@k, etc.) ?
+
+## Ressources
+- Documentation imbalanced-learn : [https://imbalanced-learn.org/stable/](https://imbalanced-learn.org/stable/)
+- Documentation scikit-learn : [Imbalanced datasets](https://scikit-learn.org/stable/modules/model_evaluation.html#classification-metrics)
+- Article : *Dealing with Imbalanced Data in Machine Learning* (Analytics Vidhya).

--- a/Cours/TP7_Pretraitement_Variables/TP_Pretraitement_Variables.md
+++ b/Cours/TP7_Pretraitement_Variables/TP_Pretraitement_Variables.md
@@ -1,6 +1,15 @@
-# TP : Prétraitement et sélection des variables
+# Parcours TP7 — Prétraitement et sélection des variables
 
-## Objectifs pédagogiques
+Ce parcours est désormais scindé en **quatre TP complémentaires**, chacun dédié à une étape clé du prétraitement. Ils peuvent être réalisés indépendamment, mais il est recommandé de les suivre dans l'ordre afin de construire progressivement un pipeline robuste.
+
+| TP | Thématique principale | Compétences travaillées |
+| --- | --- | --- |
+| [TP7.1 — Sélection de variables explicatives](TP7_1_Selection_Variables.md) | Comprendre et comparer différentes techniques de sélection de variables. | Analyse statistique, validation croisée, interprétation de modèles. |
+| [TP7.2 — Normalisation et encodage](TP7_2_Normalisation_Encodage.md) | Mettre en place des pipelines de transformation adaptés aux types de variables. | Choix des transformateurs, gestion des fuites de données, comparaison de modèles. |
+| [TP7.3 — Détection et traitement des outliers](TP7_3_Outliers.md) | Identifier et traiter les observations aberrantes avant l'entraînement. | Méthodes statistiques, détection automatique, robustesse des modèles. |
+| [TP7.4 — Classification déséquilibrée](TP7_4_Classification_Desiquilibree.md) | Adapter les modèles de classification aux jeux de données déséquilibrés. | Stratégies de rééchantillonnage, métriques adaptées, paramétrage d'algorithmes. |
+
+## Objectifs pédagogiques transverses
 
 - Comprendre les étapes clés de préparation des variables avant l'entraînement d'un modèle.
 - Savoir sélectionner les variables pertinentes et réduire la dimension.
@@ -11,16 +20,12 @@
 
 ## Prérequis
 
-- Python
-- `pandas`
-- `numpy`
-- `matplotlib`
-- `scikit-learn`
-- Notions de base sur la validation croisée et les pipelines
+- Python, `pandas`, `numpy`, `matplotlib`, `scikit-learn`.
+- Connaissances de base sur la validation croisée, les pipelines et l'évaluation de modèles (accuracy, f1-score, ROC/AUC, etc.).
 
-## Dataset proposé
+## Dataset recommandé
 
-Le TP s'appuie sur le dataset **Adult Income** (UCI Census Income) disponible via `fetch_openml`. L'objectif est de prédire si le revenu annuel dépasse 50k$ à partir de variables socio-démographiques. Le dataset contient un mélange de variables numériques et catégorielles, ainsi qu'un déséquilibre de classes modéré.
+L'ensemble des TP s'appuie sur le dataset **Adult Income** (UCI Census Income) accessible via `fetch_openml`. L'objectif est de prédire si le revenu annuel dépasse 50 k$ à partir de variables socio-démographiques (numériques et catégorielles) avec un déséquilibre modéré.
 
 ```python
 from sklearn.datasets import fetch_openml
@@ -31,241 +36,14 @@ X = adult.data
 y = adult.target
 ```
 
-## Déroulé du TP
+Vous pouvez toutefois utiliser un autre dataset tabulaire si vous le justifiez dans vos livrables.
 
-1. Exploration du dataset et identification des types de variables.
-2. Sélection de variables explicatives pertinentes.
-3. Normalisation des variables quantitatives et encodage des variables qualitatives.
-4. Détection et traitement des outliers.
-5. Stratégies pour les classifications déséquilibrées.
-6. Comparaison de pipelines (logistic regression vs XGBoost) pour mesurer l'impact du prétraitement.
-7. Synthèse et recommandations.
+## Livrables attendus
 
----
+Pour chaque TP, fournissez :
 
-## Partie 1 — Sélection de variables explicatives
+1. Un notebook Jupyter documenté contenant le code, les visualisations et les réponses aux questions.
+2. Une synthèse de 5 à 10 lignes mettant en avant les principaux enseignements (choix effectués, limites rencontrées, axes d'amélioration).
+3. Les hyperparamètres retenus et les métriques pertinentes pour la comparaison de vos modèles.
 
-### Objectif
-
-Identifier les variables les plus pertinentes pour expliquer la variable cible, réduire le bruit et améliorer la généralisation du modèle.
-
-### Méthodes classiques
-
-1. **Analyse univariée** : tester l'association de chaque variable avec la cible.
-   - Variables numériques : `f_classif`, `mutual_info_classif`.
-   - Variables catégorielles : `chi2` (après encodage non négatif).
-2. **Méthodes basées sur un modèle** : `SelectFromModel` avec `RandomForestClassifier` ou `Lasso`.
-3. **Méthodes séquentielles** : `SequentialFeatureSelector` (forward/backward) en utilisant une validation croisée.
-
-### Exemple de code (sélection univariée)
-
-```python
-from sklearn.feature_selection import SelectKBest, mutual_info_classif
-from sklearn.preprocessing import OneHotEncoder
-from sklearn.compose import ColumnTransformer
-from sklearn.pipeline import Pipeline
-from sklearn.linear_model import LogisticRegression
-
-numeric_features = X.select_dtypes(include=["int64", "float64"]).columns
-categorical_features = X.select_dtypes(include=["object", "category"]).columns
-
-preprocess = ColumnTransformer(
-    transformers=[
-        ("num", "passthrough", numeric_features),
-        ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features),
-    ]
-)
-
-selector = SelectKBest(score_func=mutual_info_classif, k=20)
-model = LogisticRegression(max_iter=1000)
-
-pipe = Pipeline([
-    ("preprocess", preprocess),
-    ("select", selector),
-    ("clf", model),
-])
-
-pipe.fit(X, y)
-```
-
-### À propos de XGBoost
-
-- XGBoost gère implicitement la sélection de variables grâce aux pénalités de complexité et aux scores de gain lors des splits.
-- Malgré tout, supprimer les variables bruyantes peut accélérer l'entraînement et améliorer la robustesse.
-- Sur des datasets volumineux ou très corrélés, une sélection préalable reste recommandée.
-
-### Exercices
-
-1. Tester trois valeurs de `k` dans `SelectKBest` et comparer l'`accuracy` et le `f1-score` sur un set de validation.
-2. Utiliser `SelectFromModel` avec un `RandomForestClassifier` et comparer les variables retenues avec celles de l'analyse univariée.
-3. Mesurer l'impact de la sélection des variables sur le temps d'entraînement d'un modèle XGBoost.
-
----
-
-## Partie 2 — Normalisation et encodage des variables
-
-### Objectif
-
-Mettre toutes les variables sur une échelle comparable et convertir les catégories en représentations numériques appropriées pour l'entraînement.
-
-### Méthodes classiques
-
-1. **Normalisation / standardisation** : `StandardScaler`, `MinMaxScaler`, `RobustScaler`.
-2. **Encodage des qualitatives** :
-   - `OneHotEncoder` pour les modèles linéaires ou les distances.
-   - `OrdinalEncoder` si l'ordre des modalités est connu.
-   - `TargetEncoder` (nécessite une validation stricte pour éviter les fuites).
-3. **Pipelines intégrés** pour garantir la reproductibilité (`ColumnTransformer`).
-
-### Exemple de code (pipeline complet)
-
-```python
-from sklearn.preprocessing import StandardScaler
-from sklearn.compose import ColumnTransformer
-from sklearn.pipeline import Pipeline
-from sklearn.linear_model import LogisticRegression
-
-numeric_transformer = Pipeline([
-    ("scaler", StandardScaler()),
-])
-
-categorical_transformer = Pipeline([
-    ("encoder", OneHotEncoder(handle_unknown="ignore")),
-])
-
-preprocess = ColumnTransformer(
-    transformers=[
-        ("num", numeric_transformer, numeric_features),
-        ("cat", categorical_transformer, categorical_features),
-    ]
-)
-
-clf = Pipeline([
-    ("preprocess", preprocess),
-    ("model", LogisticRegression(max_iter=1000)),
-])
-
-clf.fit(X, y)
-```
-
-### À propos de XGBoost
-
-- XGBoost supporte nativement les variables numériques non normalisées grâce aux arbres de décision.
-- Les variables catégorielles peuvent être gérées via `enable_categorical=True` (après les avoir converties en catégories encodées en entiers) mais l'encodage one-hot reste souvent plus performant.
-- Sur les variables très scalées ou à grande amplitude, la normalisation n'est pas obligatoire pour XGBoost mais peut aider d'autres modèles (régression logistique, SVM, kNN) dans un pipeline comparatif.
-
-### Exercices
-
-1. Comparer les performances d'une régression logistique avec `StandardScaler` vs `MinMaxScaler`.
-2. Construire deux pipelines : l'un avec `OneHotEncoder`, l'autre en utilisant l'option catégorielle native de XGBoost (`enable_categorical=True`). Discuter des résultats.
-3. Tester un `TargetEncoder` (ex. via `category_encoders`) en respectant une validation croisée, et comparer avec `OneHotEncoder`.
-
----
-
-## Partie 3 — Détection et traitement des outliers
-
-### Objectif
-
-Identifier les observations atypiques susceptibles de fausser l'entraînement ou les métriques d'évaluation.
-
-### Méthodes classiques
-
-1. **Statistiques univariées** : écart interquartile (IQR), z-score.
-2. **Modèles de détection** : `IsolationForest`, `LocalOutlierFactor`, `OneClassSVM`.
-3. **Visualisations** : boxplots, scatter plots, projections PCA.
-4. **Stratégies de traitement** : suppression, winsorisation, transformation log, modèles robustes.
-
-### Exemple de code (IsolationForest)
-
-```python
-from sklearn.ensemble import IsolationForest
-
-iso = IsolationForest(contamination=0.02, random_state=42)
-outlier_flags = iso.fit_predict(X[numeric_features])  # -1 = outlier, 1 = normal
-
-# Filtrer les outliers pour réentraîner un modèle
-mask = outlier_flags == 1
-X_clean = X.loc[mask]
-y_clean = y.loc[mask]
-```
-
-### À propos de XGBoost
-
-- Les arbres de décision sont relativement robustes aux outliers, surtout si les valeurs extrêmes ne dominent pas les splits.
-- Toutefois, la présence d'outliers peut ralentir le processus de split ou biaiser les feuilles si l'arbre doit créer des seuils spécifiques.
-- Sur des modèles linéaires, les outliers ont un effet bien plus prononcé ; comparer les performances avec et sans nettoyage peut éclairer les choix de pipeline.
-
-### Exercices
-
-1. Utiliser l'approche IQR pour repérer les valeurs aberrantes sur `capital-gain` et `hours-per-week`. Quel pourcentage d'observations est filtré ?
-2. Mettre en place un pipeline où l'on retire les outliers détectés par `IsolationForest` avant l'entraînement d'une régression logistique. Comparer les métriques.
-3. Évaluer l'impact du filtrage des outliers sur un modèle XGBoost : gain en performance ? variation du temps d'entraînement ?
-
----
-
-## Partie 4 — Classification déséquilibrée (Unbalanced)
-
-### Objectif
-
-Adapter les modèles pour optimiser les performances lorsque les classes positives sont rares ou très minoritaires.
-
-### Méthodes classiques
-
-1. **Rééchantillonnage** :
-   - Sur-échantillonnage (`RandomOverSampler`, `SMOTE`).
-   - Sous-échantillonnage (`RandomUnderSampler`).
-2. **Pondération des classes** : `class_weight="balanced"` pour les modèles scikit-learn.
-3. **Seuil de décision ajusté** : optimisation du seuil via la courbe ROC ou PR.
-4. **Métriques adaptées** : `f1`, `balanced_accuracy`, `roc_auc`, `average_precision`.
-
-### Exemple de code (pipeline avec SMOTE)
-
-```python
-from imblearn.over_sampling import SMOTE
-from imblearn.pipeline import Pipeline as ImbPipeline
-from sklearn.metrics import classification_report
-from sklearn.model_selection import train_test_split
-
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, test_size=0.2, stratify=y, random_state=42
-)
-
-imb_pipe = ImbPipeline([
-    ("preprocess", preprocess),
-    ("smote", SMOTE(random_state=42)),
-    ("clf", LogisticRegression(max_iter=1000, class_weight="balanced")),
-])
-
-imb_pipe.fit(X_train, y_train)
-y_pred = imb_pipe.predict(X_test)
-print(classification_report(y_test, y_pred))
-```
-
-### À propos de XGBoost
-
-- XGBoost offre le paramètre `scale_pos_weight` pour pondérer la classe minoritaire (`scale_pos_weight = négatifs/positifs`).
-- Le booster gère bien les jeux déséquilibrés si le paramètre est correctement réglé et si l'on surveille des métriques adaptées (`auc`, `aucpr`).
-- Combiner le pondération avec un léger sur-échantillonnage peut améliorer la stabilité, mais attention au risque d'overfitting.
-
-### Exercices
-
-1. Comparer trois stratégies : `class_weight="balanced"`, `SMOTE` + classe équilibrée, et réglage de `scale_pos_weight` pour XGBoost. Quelle combinaison offre le meilleur `f1-score` ?
-2. Tracer la courbe `precision-recall` d'une régression logistique entraînée avec `SMOTE`. Choisir un seuil de décision optimisé pour maximiser le `f1`.
-3. Entraîner un modèle XGBoost sans aucun rééquilibrage, puis avec `scale_pos_weight`. Comparer les `auc` et `average_precision`.
-
----
-
-## Synthèse et livrables
-
-- Comparer deux pipelines complets :
-  1. Prétraitement + sélection + logistic regression.
-  2. Prétraitement minimal + XGBoost avec réglage de `scale_pos_weight`.
-- Rédiger une synthèse (10 lignes) discutant :
-  - des choix de sélection de variables,
-  - de l'impact de la normalisation/encodage,
-  - de la gestion des outliers,
-  - de la stratégie pour les classes déséquilibrées,
-  - de l'apport (ou non) d'XGBoost.
-- Fournir un notebook Jupyter documenté comprenant le code, les graphiques et les réponses aux questions.
-
-Bon TP !
+Une synthèse globale (10 à 15 lignes) est demandée en fin de parcours pour relier vos conclusions.


### PR DESCRIPTION
## Summary
- restructure the TP7 overview into an index pointing to four focused workshops
- add dedicated TP7.1 to TP7.4 markdown guides with detailed activities and deliverables for selection, encoding, outliers, and imbalance handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ad39bf74832e935e24b4f763635b