### PR TITLE
Ajoute des liens croisés entre le README et les TP

### DIFF
--- a/Cours/TP1/TP_Pandas_Enonce.md
+++ b/Cours/TP1/TP_Pandas_Enonce.md
@@ -1,5 +1,7 @@
 # TP Pandas (≈ 1h) — Dataset Iris
 
+[⬅️ Retour au README](../../README.md)
+
 ## Objectifs
 
 - Télécharger un jeu de données existant (Iris via scikit-learn), le charger dans pandas puis réaliser des manipulations et des visualisations avec matplotlib.

--- a/Cours/TP2_Clustering/TP2_enonce.md
+++ b/Cours/TP2_Clustering/TP2_enonce.md
@@ -1,5 +1,7 @@
 # TP2 – Clustering par K-Means
 
+[⬅️ Retour au README](../../README.md)
+
 ## Introduction au clustering
 
 Le clustering est une famille de méthodes d'apprentissage non supervisé qui regroupe automatiquement des observations similaires. L'objectif est de révéler des structures latentes dans les données afin de mieux comprendre des comportements, personnaliser des offres ou détecter des anomalies.

--- a/Cours/TP3_Classification/TP_Classification_ML_Enonce_v3.md
+++ b/Cours/TP3_Classification/TP_Classification_ML_Enonce_v3.md
@@ -1,5 +1,7 @@
 # TP : Classification en Machine Learning
 
+[⬅️ Retour au README](../../README.md)
+
 ## Algorithmes de classification utilisés
 
 Avant de commencer le TP, nous allons présenter les algorithmes qui seront utilisés. Chaque méthode a ses forces, ses faiblesses et ses paramètres clés à optimiser. Des schémas et images sont fournis (liens ou générés automatiquement) pour aider à la compréhension.

--- a/Cours/TP4_XGBoost/TP4_XGBoost_Avance.md
+++ b/Cours/TP4_XGBoost/TP4_XGBoost_Avance.md
@@ -1,5 +1,7 @@
 # TP 4 : XGBoost avancé et gestion d'un ensemble de validation
 
+[⬅️ Retour au README](../../README.md)
+
 ## Objectifs pédagogiques
 
 - Comprendre l'intérêt d'un ensemble de validation lors de l'entraînement d'un modèle XGBoost.

--- a/Cours/TP5_Regression/TP_Regression_Validation.md
+++ b/Cours/TP5_Regression/TP_Regression_Validation.md
@@ -1,5 +1,7 @@
 # TP : Régression, validation croisée et contrôle de la complexité
 
+[⬅️ Retour au README](../../README.md)
+
 ## Objectifs pédagogiques
 
 - Comprendre la différence entre un problème de classification et un problème de régression.

--- a/Cours/TP6_XGBoost_Objectif_Metriques/TP6_XGBoost_Objectif_Metriques.md
+++ b/Cours/TP6_XGBoost_Objectif_Metriques/TP6_XGBoost_Objectif_Metriques.md
@@ -1,5 +1,7 @@
 # TP 6 : XGBoost – Fonctions objectives et métriques
 
+[⬅️ Retour au README](../../README.md)
+
 ## Objectifs pédagogiques
 
 - Comprendre le rôle de la fonction objective dans XGBoost et savoir la choisir selon le problème.

--- a/Cours/TP7_Pretraitement_Variables/TP7_1_Selection_Variables.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_1_Selection_Variables.md
@@ -1,5 +1,7 @@
 # TP7.1 — Sélection de variables explicatives
 
+[⬅️ Retour au README](../../README.md)
+
 ## Positionnement pédagogique
 - **Durée indicative** : 3 heures.
 - **Niveau** : étudiants de 3e année de BUT Informatique (parcours IA/Data).

--- a/Cours/TP7_Pretraitement_Variables/TP7_2_Normalisation_Encodage.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_2_Normalisation_Encodage.md
@@ -1,5 +1,7 @@
 # TP7.2 — Normalisation et encodage des variables
 
+[⬅️ Retour au README](../../README.md)
+
 ## Positionnement pédagogique
 - **Durée indicative** : 3 heures.
 - **Niveau** : BUT3 Informatique.

--- a/Cours/TP7_Pretraitement_Variables/TP7_3_Outliers.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_3_Outliers.md
@@ -1,5 +1,7 @@
 # TP7.3 — Détection et traitement des outliers
 
+[⬅️ Retour au README](../../README.md)
+
 ## Positionnement pédagogique
 - **Durée indicative** : 2h30.
 - **Niveau** : BUT3 Informatique.

--- a/Cours/TP7_Pretraitement_Variables/TP7_4_Classification_Desiquilibree.md
+++ b/Cours/TP7_Pretraitement_Variables/TP7_4_Classification_Desiquilibree.md
@@ -1,5 +1,7 @@
 # TP7.4 — Classification déséquilibrée
 
+[⬅️ Retour au README](../../README.md)
+
 ## Positionnement pédagogique
 - **Durée indicative** : 3 heures.
 - **Niveau** : BUT3 Informatique.

--- a/Cours/TP7_Pretraitement_Variables/TP_Pretraitement_Variables.md
+++ b/Cours/TP7_Pretraitement_Variables/TP_Pretraitement_Variables.md
@@ -1,5 +1,7 @@
 # Parcours TP7 — Prétraitement et sélection des variables
 
+[⬅️ Retour au README](../../README.md)
+
 Ce parcours est désormais scindé en **quatre TP complémentaires**, chacun dédié à une étape clé du prétraitement. Ils peuvent être réalisés indépendamment, mais il est recommandé de les suivre dans l'ordre afin de construire progressivement un pipeline robuste.
 
 | TP | Thématique principale | Compétences travaillées |

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 - Savoir évaluer et améliorer les performances des modèles en utilisant des métriques adaptées et des techniques de préparation des données.
 
 ## Travaux pratiques
-1. **TP1 – Découverte de pandas** : prise en main de la manipulation de données tabulaires et des opérations courantes de nettoyage.
-2. **TP2 – Clustering** : mise en œuvre d'algorithmes de regroupement non supervisé (k-means, analyse visuelle de l'inertie, etc.).
-3. **TP3 – Classification supervisée** : application d'algorithmes de classification et évaluation des performances.
-4. **TP4 – XGBoost avancé** : découverte et paramétrage d'un modèle de gradient boosting pour la classification.
-5. **TP5 – Régression** : mise en place d'un pipeline de régression et analyse des métriques associées.
-6. **TP6 – Objectifs et métriques XGBoost** *(facultatif)* : exploration d'objectifs personnalisés et des métriques avancées pour XGBoost.
-7. **TP7 – Prétraitement des variables** *(facultatif)* : techniques de sélection, normalisation, encodage et traitement des données déséquilibrées.
+1. [**TP1 – Découverte de pandas**](Cours/TP1/TP_Pandas_Enonce.md) : prise en main de la manipulation de données tabulaires et des opérations courantes de nettoyage.
+2. [**TP2 – Clustering**](Cours/TP2_Clustering/TP2_enonce.md) : mise en œuvre d'algorithmes de regroupement non supervisé (k-means, analyse visuelle de l'inertie, etc.).
+3. [**TP3 – Classification supervisée**](Cours/TP3_Classification/TP_Classification_ML_Enonce_v3.md) : application d'algorithmes de classification et évaluation des performances.
+4. [**TP4 – XGBoost avancé**](Cours/TP4_XGBoost/TP4_XGBoost_Avance.md) : découverte et paramétrage d'un modèle de gradient boosting pour la classification.
+5. [**TP5 – Régression**](Cours/TP5_Regression/TP_Regression_Validation.md) : mise en place d'un pipeline de régression et analyse des métriques associées.
+6. [**TP6 – Objectifs et métriques XGBoost**](Cours/TP6_XGBoost_Objectif_Metriques/TP6_XGBoost_Objectif_Metriques.md) *(facultatif)* : exploration d'objectifs personnalisés et des métriques avancées pour XGBoost.
+7. [**TP7 – Prétraitement des variables**](Cours/TP7_Pretraitement_Variables/TP_Pretraitement_Variables.md) *(facultatif)* : techniques de sélection, normalisation, encodage et traitement des données déséquilibrées.
 
 Les TP 6 et 7 sont proposés pour aller plus loin et peuvent être réalisés en autonomie en fonction de votre progression.


### PR DESCRIPTION
## Summary
- ajoute des hyperliens dans le README vers les principaux énoncés de TP
- ajoute un lien de retour vers le README en tête de chaque énoncé de TP

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7af7002ac832e9cc09c437adf1c3f